### PR TITLE
Rolling back the spring version to 5.3.3 because of an incompatibility…

### DIFF
--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -1,7 +1,6 @@
 *Version 4.3.3*
 * Upgrade library version to jssc 2.9.4
 * Upgrade Jackson library version to 2.13.1
-* Upgrade Spring library version to 5.3.7
 * Upgrade MySQL java connector library version to 8.0.27
 * Fix bug that occurs when attempting to validate any script on a non-running Script data source, causing it will get into a state where it cannot be re-validated or started
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
     <properties>
         <jettyVersion>9.4.43.v20210629</jettyVersion>
-        <springVersion>5.3.7</springVersion>
+        <springVersion>5.3.3</springVersion>
         <springSecurityVersion>5.4.2</springSecurityVersion>
         <log4jVersion>2.17.1</log4jVersion>
         <slf4jVersion>1.8.0-beta4</slf4jVersion>


### PR DESCRIPTION
… with the Mango API module

There is a problem updating the spring library to 5.3.7, it brakes the “mango-root>ma-modules-public>Mango API“  because the objectMapper is no longer exposed and the classes:
com.infiniteautomation.mango.rest.latest.mapping.PointValueTimeStreamCsvMessageConverter
com.infiniteautomation.mango.rest.latest.mapping.JsonStreamMessageConverter
com.infiniteautomation.mango.rest.latest.genericcsv.GenericCSVMessageConverter

RAD-1834