### PR TITLE
RAD-2443: fix date location language issue

### DIFF
--- a/Core/src/com/serotonin/m2m2/rt/maint/work/BackupWorkItem.java
+++ b/Core/src/com/serotonin/m2m2/rt/maint/work/BackupWorkItem.java
@@ -7,6 +7,8 @@ import java.io.FilenameFilter;
 import java.io.StringWriter;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
@@ -112,7 +114,7 @@ public class BackupWorkItem implements WorkItem {
             LOG.info("Starting backup WorkItem.");
             // Create the filename
             String filename = "Mango-Configuration";
-            String runtimeString = new SimpleDateFormat(BACKUP_DATE_FORMAT).format(new Date());
+            String runtimeString = DateTimeFormatter.ofPattern(BACKUP_DATE_FORMAT).format(LocalDateTime.now());
             int maxFiles = SystemSettingsDao.getInstance().getIntValue(SystemSettingsDao.BACKUP_FILE_COUNT);
             // If > 1 then we will use a date in the filename
             if (maxFiles > 1) {

--- a/Core/src/com/serotonin/m2m2/rt/maint/work/BackupWorkItem.java
+++ b/Core/src/com/serotonin/m2m2/rt/maint/work/BackupWorkItem.java
@@ -36,7 +36,6 @@ public class BackupWorkItem implements WorkItem {
     private static final String TASK_ID = "CONFIG_BACKUP";
 
     public static final String BACKUP_DATE_FORMAT = "MMM-dd-yyyy_HHmmss"; //Used to for filename and property value for last run
-    public static final String TURKISH_LANGUAGE = "Tr";
 
     //Lock to ensure we don't clobber files by running a backup
     // during another one.
@@ -113,7 +112,8 @@ public class BackupWorkItem implements WorkItem {
             LOG.info("Starting backup WorkItem.");
             // Create the filename
             String filename = "Mango-Configuration";
-            String runtimeString = new SimpleDateFormat(BACKUP_DATE_FORMAT, Locale.US).format(new Date());
+            Date runtimeDate = new Date();
+            String runtimeString = new SimpleDateFormat(BACKUP_DATE_FORMAT).format(runtimeDate);
             int maxFiles = SystemSettingsDao.getInstance().getIntValue(SystemSettingsDao.BACKUP_FILE_COUNT);
             // If > 1 then we will use a date in the filename
             if (maxFiles > 1) {
@@ -161,7 +161,7 @@ public class BackupWorkItem implements WorkItem {
 
                 // Store the last successful backup time
                 SystemSettingsDao.getInstance().setValue(SystemSettingsDao.BACKUP_LAST_RUN_SUCCESS,
-                        runtimeString);
+                    String.valueOf(runtimeDate.getTime()));
 
                 // Clean up old files, keeping the correct number as the history
                 File backupDir = new File(this.backupLocation);
@@ -227,7 +227,7 @@ public class BackupWorkItem implements WorkItem {
 
                 //Have we ever run?
                 if(lastRunDateString != null){
-                    Date lastRunDate = getLastRunDate(lastRunDateString);
+                    Date lastRunDate = DateUtils.getLastRunDate(lastRunDateString);
                     DateTime lastRun = new DateTime(lastRunDate);
                     //Compute the next run time off of the last run time
                     DateTime nextRun = DateUtils.plus(lastRun, SystemSettingsDao.getInstance().getIntValue(SystemSettingsDao.BACKUP_PERIOD_TYPE),
@@ -248,20 +248,6 @@ public class BackupWorkItem implements WorkItem {
 
             }
         }//end run
-
-        private Date getLastRunDate(String lastRunDateString) {
-            try {
-                return new SimpleDateFormat(BACKUP_DATE_FORMAT, Locale.US).parse(lastRunDateString);
-            } catch (ParseException parseException) {
-                try {
-                    return new SimpleDateFormat(BACKUP_DATE_FORMAT,
-                        Locale.of(TURKISH_LANGUAGE)).parse(lastRunDateString);
-                } catch (ParseException e) {
-                    LOG.warn("Failed to parse last backup date, using Jan 1 1970.", e);
-                    return new Date();
-                }
-            }
-        }
 
     }// end backup settings task
 

--- a/Core/src/com/serotonin/m2m2/rt/maint/work/BackupWorkItem.java
+++ b/Core/src/com/serotonin/m2m2/rt/maint/work/BackupWorkItem.java
@@ -6,11 +6,9 @@ import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.StringWriter;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -228,11 +226,12 @@ public class BackupWorkItem implements WorkItem {
 
                 //Have we ever run?
                 if(lastRunDateString != null){
-                    Date lastRunDate;
+                    LocalDateTime lastRunDate;
                     try {
-                        lastRunDate = new SimpleDateFormat(BACKUP_DATE_FORMAT).parse(lastRunDateString);
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(BACKUP_DATE_FORMAT);
+                        lastRunDate = LocalDateTime.parse(lastRunDateString, formatter);
                     }catch(Exception e) {
-                        lastRunDate = new Date();
+                        lastRunDate = LocalDateTime.now();
                         LOG.warn("Failed to parse last backup date, using Jan 1 1970.", e);
                     }
                     DateTime lastRun = new DateTime(lastRunDate);

--- a/Core/src/com/serotonin/m2m2/rt/maint/work/DatabaseBackupWorkItem.java
+++ b/Core/src/com/serotonin/m2m2/rt/maint/work/DatabaseBackupWorkItem.java
@@ -126,13 +126,13 @@ public class DatabaseBackupWorkItem implements WorkItem {
             // Create the filename
             String filename = "core-database-" + Common.getBean(DatabaseProxy.class).getType();
             SimpleDateFormat dateFormatter = new SimpleDateFormat(BACKUP_DATE_FORMAT);
-            String runtimeString = dateFormatter.format(new Date());
+            String runtimeString = String.valueOf(new Date().getTime());
             int maxFiles = SystemSettingsDao.getInstance().getIntValue(SystemSettingsDao.DATABASE_BACKUP_FILE_COUNT);
             // If > 1 then we will use a date in the filename
             if (maxFiles > 1) {
                 // Create Mango-Configuration-date.json
                 filename += "-";
-                filename += runtimeString;
+                filename += dateFormatter.format(new Date(Long.parseLong(runtimeString)));
             }
 
             Path backupFilePath = Paths.get(this.backupLocation).resolve(filename + ".zip").toAbsolutePath().normalize();
@@ -250,14 +250,7 @@ public class DatabaseBackupWorkItem implements WorkItem {
 
                 // Have we ever run?
                 if (lastRunDateString != null) {
-                    SimpleDateFormat dateFormatter = new SimpleDateFormat(BACKUP_DATE_FORMAT);
-                    Date lastRunDate;
-                    try{
-                        lastRunDate = dateFormatter.parse(lastRunDateString);
-                    }catch(Exception e) {
-                        lastRunDate = new Date();
-                        LOG.warn("Failed to parse last backup date, using Jan 1 1970.", e);
-                    }
+                    Date lastRunDate = DateUtils.getLastRunDate(lastRunDateString);
                     DateTime lastRun = new DateTime(lastRunDate);
                     // Compute the next run time off of the last run time
                     DateTime nextRun = DateUtils.plus(lastRun,

--- a/Core/src/com/serotonin/m2m2/util/DateUtils.java
+++ b/Core/src/com/serotonin/m2m2/util/DateUtils.java
@@ -3,16 +3,27 @@
  */
 package com.serotonin.m2m2.util;
 
+import com.serotonin.m2m2.db.dao.SystemSettingsDao;
+import com.serotonin.m2m2.rt.maint.work.BackupWorkItem;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 import org.joda.time.DateTime;
 
 import com.serotonin.m2m2.Common;
 import com.serotonin.m2m2.Common.TimePeriods;
 import com.serotonin.m2m2.i18n.TranslatableMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Matthew Lohbihler
  */
 public class DateUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DateUtils.class);
     public static long minus(long time, int periodType, int periods) {
         return minus(new DateTime(time), periodType, periods).getMillis();
     }
@@ -152,6 +163,61 @@ public class DateUtils {
         // Convert to days
         duration /= 24;
         return new TranslatableMessage("common.tp.gtDescription", duration, new TranslatableMessage("common.tp.days"));
+    }
+
+    /**
+     * Ticket RAD-2443 This is trying to fix the issue cause by a system language change so some dates were store in some language
+     * and when those are read a parse exceptions occurred. So the solution is to store lastRunDate as long number and to read it we have 3 options:
+     * 1) Try to parse with the current system language.
+     * 2) Try to read the date from a long.
+     * 3) Try to parse the date, base on java available locales. In this case it will store the date as long so it will be faster to find it next time.
+     * @param lastRunDateString this field is the last execution date stored into the database.
+     * 1) lastRunDateString could come like Nov-07-2023_214128
+     * 2) lastRunDateString could come like 1699414888000
+     * 3) lastRunDateString could come like Kas-07-2023_214128
+     * @return parsed date.
+     */
+    public static Date getLastRunDate(String lastRunDateString) {
+        try {
+            // first try will be trying to parse lastRunDate with current system language; example: Nov-07-2023_214128 to Date
+            return new SimpleDateFormat(BackupWorkItem.BACKUP_DATE_FORMAT).parse(lastRunDateString);
+        } catch (ParseException parseException) {
+            try {
+                // second try will be trying to parse Date from long; example: 1699414888000
+                return new Date(Long.parseLong(lastRunDateString));
+            } catch (Exception e) {
+                // third try will be trying to parse lastRunDate from different languages; example: Kas-07-2023_214128 to Date
+                Date date = figureOutDateLanguage(lastRunDateString);
+                if(date == null) {
+                    LOG.warn("Failed to parse last backup date, using Jan 1 1970.", e);
+                    date = new Date();
+                }
+                return date;
+            }
+        }
+    }
+
+    private static Date figureOutDateLanguage(String dateString) {
+        Locale locales[] = DateFormat.getAvailableLocales();
+        Date date = null;
+        for (Locale locale : locales) {
+            date = formatStringDate(dateString, locale);
+            if (date != null) {
+                // Store the last successful backup time
+                SystemSettingsDao.getInstance().setValue(SystemSettingsDao.BACKUP_LAST_RUN_SUCCESS,
+                    String.valueOf(date.getTime()));
+                break;
+            }
+        }
+        return date;
+    }
+
+    private static Date formatStringDate(String dateString, Locale locale) {
+        try {
+            return new SimpleDateFormat(BackupWorkItem.BACKUP_DATE_FORMAT, locale).parse(dateString);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Ticket [RAD-2443](https://radixiot.atlassian.net/browse/RAD-2443) where it is reported that when backup process is running and when backup file name is built when getting the current date it is happening an issue as current system date is like: 

`Kas-04-2022_111111` 

so as the month is in Turkish when it is trying to format that date to the following format:

`MMM-dd-yyyy_HHmmss`

the following exception happened as it is trying to load that date as an English date:

`java.text.ParseException: Unparseable date: "04 Kas 2022"`

Solution: We will store last execution date as a Long but on a String field.

so now we will face 4 posible scenarios:

1) when date is like Nov-04-2022_111111

2) when date is like 1699414888000 (stored as a long into an String)

3) when date is in any laguage different from the system; for example: Kas-07-2023_214128

4) a not parsable format; for example: abc-99-9999_999999


[RAD-2443]: https://radixiot.atlassian.net/browse/RAD-2443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ