### PR TITLE
gRPC protocol for PTCP publisher

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -726,6 +726,11 @@ with Springfox 3.
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
+            <artifactId>grpc-core</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc.version}</version>
             <scope>runtime</scope>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -169,6 +169,10 @@
                     </includes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -437,9 +441,9 @@ with Springfox 3.
             <version>3.4.2</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.27</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.32</version>
         </dependency>
         <dependency>
             <groupId>io.github.java-native</groupId>
@@ -715,6 +719,33 @@ with Springfox 3.
             <artifactId>metrics-core</artifactId>
             <version>4.2.4</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>annotations-api</artifactId>
+            <version>6.0.53</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Testing -->
         <dependency>
             <groupId>junit</groupId>
@@ -787,6 +818,11 @@ with Springfox 3.
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-util</artifactId>
                 <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/Core/proto/com/radixiot/mango/core/data_point.proto
+++ b/Core/proto/com/radixiot/mango/core/data_point.proto
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+syntax = "proto3";
+package com.radixiot.mango.core;
+
+option java_multiple_files = true;
+
+enum DataType {
+  DATA_TYPE_UNSPECIFIED = 0;
+  DATA_TYPE_BINARY = 1;
+  DATA_TYPE_MULTISTATE = 2;
+  DATA_TYPE_NUMERIC = 3;
+  DATA_TYPE_ALPHANUMERIC = 4;
+}
+
+message DataPoint {
+  string xid = 1;
+  string name = 2;
+  string device_name = 3;
+  DataType data_type = 4;
+  map<string, string> tags = 5;
+}

--- a/Core/proto/com/radixiot/mango/core/event.proto
+++ b/Core/proto/com/radixiot/mango/core/event.proto
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+syntax = "proto3";
+package com.radixiot.mango.core;
+
+import "com/radixiot/mango/core/data_point.proto";
+
+option java_multiple_files = true;
+
+enum AlarmLevel {
+  ALARM_LEVEL_UNSPECIFIED = 0;
+  ALARM_LEVEL_NONE = 1;
+  ALARM_LEVEL_INFORMATION = 2;
+  ALARM_LEVEL_IMPORTANT = 3;
+  ALARM_LEVEL_WARNING = 4;
+  ALARM_LEVEL_URGENT = 5;
+  ALARM_LEVEL_CRITICAL = 6;
+  ALARM_LEVEL_LIFE_SAFETY = 7;
+  ALARM_LEVEL_DO_NOT_LOG = 8;
+  ALARM_LEVEL_IGNORE = 9;
+}
+
+enum ReturnCause {
+  RETURN_CAUSE_UNSPECIFIED = 0;
+  RETURN_CAUSE_RETURN_TO_NORMAL = 1;
+  RETURN_CAUSE_SOURCE_DISABLED = 2;
+}
+
+message TranslatableArgument {
+  oneof argument {
+    string string_argument = 1;
+    Translatable translatable_argument = 2;
+  }
+}
+
+message Translatable {
+  string key = 1;
+  repeated TranslatableArgument parameters = 2;
+}
+
+message Event {
+  AlarmLevel alarm_level = 1;
+  int64 timestamp = 2;
+  string event_message = 3;
+  Translatable translatable_event_message = 4;
+  bool returns_to_normal = 5;
+  optional int64 inactive_timestamp = 6;
+  optional ReturnCause return_cause = 7;
+  optional DataPoint data_point = 8;
+}

--- a/Core/proto/com/radixiot/mango/core/event.proto
+++ b/Core/proto/com/radixiot/mango/core/event.proto
@@ -37,7 +37,7 @@ message TranslatableArgument {
 
 message Translatable {
   string key = 1;
-  repeated TranslatableArgument parameters = 2;
+  repeated TranslatableArgument arguments = 2;
 }
 
 message Event {

--- a/Core/proto/com/radixiot/mango/core/point_value.proto
+++ b/Core/proto/com/radixiot/mango/core/point_value.proto
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+syntax = "proto3";
+package com.radixiot.mango.core;
+option java_multiple_files = true;
+
+message PointValue {
+  string data_point_xid = 1;
+  int64 timestamp = 2;
+  double value = 3;
+}

--- a/Core/proto/com/radixiot/mango/core/point_value.proto
+++ b/Core/proto/com/radixiot/mango/core/point_value.proto
@@ -9,5 +9,10 @@ option java_multiple_files = true;
 message PointValue {
   string data_point_xid = 1;
   int64 timestamp = 2;
-  double value = 3;
+  oneof value {
+    bool binary_value = 4;
+    int32 multistate_value = 5;
+    double numeric_value = 6;
+    string alphanumeric_value = 7;
+  }
 }

--- a/Core/resources/log4j2.xml
+++ b/Core/resources/log4j2.xml
@@ -96,6 +96,7 @@
 		</AsyncLogger>
 		<AsyncLogger name="com.serotonin.m2m2" includeLocation="${mango:logger.mango.includeLocation}" level="${mango:logger.mango.level}"/>
 		<AsyncLogger name="com.infiniteautomation" includeLocation="${mango:logger.mango.includeLocation}" level="${mango:logger.mango.level}"/>
+		<AsyncLogger name="com.radixiot" includeLocation="${mango:logger.mango.includeLocation}" level="${mango:logger.mango.level}"/>
 		<AsyncRoot includeLocation="${mango:logger.root.includeLocation}" level="${mango:logger.root.level}">
 			<AppenderRef ref="logfile" level="${mango:appender.logfile.level}" />
 			<AppenderRef ref="stdout" level="${mango:appender.stdout.level}" />

--- a/Core/resources/mango.properties
+++ b/Core/resources/mango.properties
@@ -628,3 +628,23 @@ oauth2.client.default.userMapping.roles.suffix=
 #oauth2.client.default.userMapping.roles.map.xyz=superadmin
 # add additional roles to the user (comma separated list), user role is added implicitly
 oauth2.client.default.userMapping.roles.add=
+
+# Enable gRPC server
+grpc.server.enabled=true
+# gRPC server port
+grpc.server.port=9090
+# Server X.509 certificate, including full certificate chain. Path to file (in PEM format).
+#grpc.server.certChain=
+# Server private key. Path to file (in PEM format).
+#grpc.server.privateKey=
+# Root certificates for verification of client certificates (mTLS). Path to file (in PEM format).
+#grpc.server.rootCerts=
+# Client authentication options (mTLS): NONE/OPTIONAL/REQUIRE
+grpc.server.clientAuth=NONE
+
+# Client X.509 certificate, including full certificate chain. Path to file (in PEM format).
+#grpc.client.certChain=
+# Client private key. Path to file (in PEM format).
+#grpc.client.privateKey=
+# Root certificates for verification of server certificate. Path to file (in PEM format).
+#grpc.client.rootCerts=

--- a/Core/resources/mango.properties
+++ b/Core/resources/mango.properties
@@ -631,7 +631,7 @@ oauth2.client.default.userMapping.roles.add=
 
 # Enable gRPC server
 grpc.server.enabled=true
-# gRPC server port
+# gRPC server TCP port
 grpc.server.port=9090
 # Server X.509 certificate, including full certificate chain. Path to file (in PEM format).
 #grpc.server.certChain=

--- a/Core/src-test/com/serotonin/m2m2/MockMangoProperties.java
+++ b/Core/src-test/com/serotonin/m2m2/MockMangoProperties.java
@@ -45,6 +45,9 @@ public class MockMangoProperties implements MangoProperties {
         setProperty("serial.port.linux.path", "/dev/");
         setProperty("serial.port.osx.regex", "null");
         setProperty("serial.port.osx.path", "/dev/");
+
+        // use an in-process gRPC server (disables TCP port)
+        setProperty("grpc.server.inProcessServer", "mango");
     }
 
     public void setProperty(String key, String value) {

--- a/Core/src-test/com/serotonin/m2m2/rt/publish/PublisherRTQueueMonitorTest.java
+++ b/Core/src-test/com/serotonin/m2m2/rt/publish/PublisherRTQueueMonitorTest.java
@@ -39,7 +39,6 @@ import com.serotonin.m2m2.vo.DataPointVO;
 import com.serotonin.m2m2.vo.dataPoint.MockPointLocatorVO;
 import com.serotonin.m2m2.vo.dataSource.mock.MockDataSourceVO;
 import com.serotonin.m2m2.vo.publish.PublishedPointVO;
-import com.serotonin.m2m2.vo.publish.PublisherVO;
 import com.serotonin.m2m2.vo.publish.mock.MockPublishedPointVO;
 import com.serotonin.m2m2.vo.publish.mock.MockPublisherDefinition;
 import com.serotonin.m2m2.vo.publish.mock.MockPublisherVO;
@@ -141,9 +140,9 @@ public class PublisherRTQueueMonitorTest extends MangoTestBase {
         }
 
         @Override
-        protected PublishQueue<MockPublishedPointVO, PointValueTime> createPublishQueue(PublisherVO vo) {
-            TestPublisherVO tPvo = (TestPublisherVO)vo;
-            return new TestPublishQueue(this, tPvo.getCacheWarningSize(), tPvo.getCacheDiscardSize(), tPvo.getAddedFuture());
+        protected PublishQueue<MockPublishedPointVO, PointValueTime> createPublishQueue() {
+            TestPublisherVO tPvo = (TestPublisherVO) vo;
+            return new TestPublishQueue<>(this, tPvo.getCacheWarningSize(), tPvo.getCacheDiscardSize(), tPvo.getAddedFuture());
         }
     }
 

--- a/Core/src-test/com/serotonin/m2m2/rt/publish/PublisherRTQueueMonitorTest.java
+++ b/Core/src-test/com/serotonin/m2m2/rt/publish/PublisherRTQueueMonitorTest.java
@@ -4,6 +4,9 @@
 
 package com.serotonin.m2m2.rt.publish;
 
+import static com.serotonin.m2m2.rt.publish.PublishQueueImpl.QUEUE_SIZE_MONITOR_ID;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -40,9 +43,6 @@ import com.serotonin.m2m2.vo.publish.PublisherVO;
 import com.serotonin.m2m2.vo.publish.mock.MockPublishedPointVO;
 import com.serotonin.m2m2.vo.publish.mock.MockPublisherDefinition;
 import com.serotonin.m2m2.vo.publish.mock.MockPublisherVO;
-
-import static com.serotonin.m2m2.rt.publish.PublishQueue.QUEUE_SIZE_MONITOR_ID;
-import static org.junit.Assert.fail;
 
 @RunWith(SuperadminSecurityContextRunner.class)
 public class PublisherRTQueueMonitorTest extends MangoTestBase {
@@ -141,7 +141,7 @@ public class PublisherRTQueueMonitorTest extends MangoTestBase {
         }
 
         @Override
-        protected PublishQueue<MockPublisherVO, MockPublishedPointVO, PointValueTime> createPublishQueue(PublisherVO vo) {
+        protected PublishQueue<MockPublishedPointVO, PointValueTime> createPublishQueue(PublisherVO vo) {
             TestPublisherVO tPvo = (TestPublisherVO)vo;
             return new TestPublishQueue(this, tPvo.getCacheWarningSize(), tPvo.getCacheDiscardSize(), tPvo.getAddedFuture());
         }
@@ -156,17 +156,17 @@ public class PublisherRTQueueMonitorTest extends MangoTestBase {
         }
     }
 
-    static class TestPublishQueue extends PublishQueue {
+    static class TestPublishQueue<T extends PublishedPointVO, V> extends PublishQueueImpl<T, V> {
         private final CompletableFuture<Void> added;
 
-        public TestPublishQueue(PublisherRT owner, int warningSize, int discardSize, CompletableFuture<Void> added) {
+        public TestPublishQueue(PublisherRT<?, T, ?> owner, int warningSize, int discardSize, CompletableFuture<Void> added) {
             super(owner, warningSize, discardSize);
             this.added = added;
         }
 
         @Override
-        public void add(PublishedPointVO vo, Object pvt) {
-            super.add(vo, pvt);
+        public void add(T vo, V item) {
+            super.add(vo, item);
             added.complete(null);
         }
     }

--- a/Core/src/com/infiniteautomation/mango/spring/grpc/GrpcServerLifecycle.java
+++ b/Core/src/com/infiniteautomation/mango/spring/grpc/GrpcServerLifecycle.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+package com.infiniteautomation.mango.spring.grpc;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.grpc.BindableService;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+
+/**
+ * @author Jared Wiltshire
+ */
+@Component
+public class GrpcServerLifecycle {
+
+    private final List<BindableService> services;
+    private final int port;
+    private Server server;
+
+    @Autowired
+    public GrpcServerLifecycle(List<BindableService> services, @Value("${grpc.server.port:9090}") int port) {
+        this.services = services;
+        this.port = port;
+    }
+
+    @PostConstruct
+    synchronized void postConstruct() throws IOException {
+        var builder = ServerBuilder.forPort(port);
+        services.forEach(builder::addService);
+        this.server = builder.build().start();
+    }
+
+    @PreDestroy
+    synchronized void preDestroy() throws InterruptedException {
+        if (server != null) {
+            server.shutdown();
+            server.awaitTermination();
+            server = null;
+        }
+    }
+
+}

--- a/Core/src/com/infiniteautomation/mango/spring/grpc/GrpcServerLifecycle.java
+++ b/Core/src/com/infiniteautomation/mango/spring/grpc/GrpcServerLifecycle.java
@@ -5,44 +5,83 @@
 package com.infiniteautomation.mango.spring.grpc;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
+import com.infiniteautomation.mango.spring.ConditionalOnProperty;
+import com.serotonin.m2m2.Common;
+
 import io.grpc.BindableService;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
+import io.grpc.ServerCredentials;
 import io.grpc.ServerInterceptor;
+import io.grpc.TlsServerCredentials;
+import io.grpc.TlsServerCredentials.ClientAuth;
 import io.grpc.util.TransmitStatusRuntimeExceptionInterceptor;
 
 /**
  * @author Jared Wiltshire
  */
 @Component
+@ConditionalOnProperty("${grpc.server.enabled}")
 public class GrpcServerLifecycle {
 
+    private final Logger log = LoggerFactory.getLogger(getClass());
     private final List<BindableService> services;
     private final List<ServerInterceptor> interceptors;
     private final int port;
+    private final @Nullable Path certChain;
+    private final @Nullable Path privateKey;
+    private final @Nullable Path rootCerts;
+    private final ClientAuth clientAuth;
     private Server server;
 
     @Autowired
     public GrpcServerLifecycle(List<BindableService> services,
                                List<ServerInterceptor> interceptors,
-                               @Value("${grpc.server.port:9090}") int port) {
+                               @Value("${grpc.server.port}") int port,
+                               @Value("${grpc.server.certChain:#{null}}") @Nullable Path certChain,
+                               @Value("${grpc.server.privateKey:#{null}}") @Nullable Path privateKey,
+                               @Value("${grpc.server.rootCerts:#{null}}") @Nullable Path rootCerts,
+                               @Value("${grpc.server.clientAuth}") ClientAuth clientAuth) {
         this.services = services;
         this.interceptors = interceptors;
         this.port = port;
+        this.certChain = certChain == null ? null : Common.MA_DATA_PATH.resolve(certChain).normalize();
+        this.privateKey = privateKey == null ? null : Common.MA_DATA_PATH.resolve(privateKey).normalize();
+        this.rootCerts = rootCerts == null ? null : Common.MA_DATA_PATH.resolve(rootCerts).normalize();
+        this.clientAuth = clientAuth;
     }
 
     @PostConstruct
     synchronized void postConstruct() throws IOException {
-        var builder = ServerBuilder.forPort(port);
+        ServerCredentials serverCredentials;
+        if (certChain != null && privateKey != null) {
+            var tlsBuilder = TlsServerCredentials.newBuilder()
+                    .keyManager(certChain.toFile(), privateKey.toFile())
+                    .clientAuth(clientAuth);
+            if (rootCerts != null) {
+                tlsBuilder.trustManager(rootCerts.toFile());
+            }
+            serverCredentials = tlsBuilder.build();
+        } else {
+            log.warn("gRPC server is running without TLS! " +
+                    "You must supply a certificate chain and private key file to enable TLS.");
+            serverCredentials = InsecureServerCredentials.create();
+        }
+        var builder = Grpc.newServerBuilderForPort(port, serverCredentials);
         builder.intercept(TransmitStatusRuntimeExceptionInterceptor.instance());
         interceptors.forEach(builder::intercept);
         services.forEach(builder::addService);

--- a/Core/src/com/infiniteautomation/mango/spring/grpc/package-info.java
+++ b/Core/src/com/infiniteautomation/mango/spring/grpc/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+/**
+ * @author Jared Wiltshire
+ */
+@NonNullApi
+package com.infiniteautomation.mango.spring.grpc;
+
+import org.springframework.lang.NonNullApi;

--- a/Core/src/com/serotonin/m2m2/rt/EventManager.java
+++ b/Core/src/com/serotonin/m2m2/rt/EventManager.java
@@ -13,6 +13,7 @@ import com.serotonin.m2m2.rt.event.AlarmLevels;
 import com.serotonin.m2m2.rt.event.EventInstance;
 import com.serotonin.m2m2.rt.event.ReturnCause;
 import com.serotonin.m2m2.rt.event.UserEventListener;
+import com.serotonin.m2m2.rt.event.handlers.EventHandlerInterface;
 import com.serotonin.m2m2.rt.event.type.EventType;
 import com.serotonin.m2m2.vo.User;
 import com.serotonin.m2m2.vo.permission.PermissionHolder;
@@ -117,6 +118,10 @@ public interface EventManager extends ILifecycle {
     void addUserEventListener(UserEventListener l);
 
     void removeUserEventListener(UserEventListener l);
+
+    void addHandler(EventHandlerInterface handler);
+
+    void removeHandler(EventHandlerInterface handler);
 
     /**
      * Get all active user events that a user has permission for

--- a/Core/src/com/serotonin/m2m2/rt/event/EventInstance.java
+++ b/Core/src/com/serotonin/m2m2/rt/event/EventInstance.java
@@ -237,8 +237,9 @@ public class EventInstance implements EventInstanceI {
         return handlers;
     }
 
-    public void setHandlers(@NonNull List<EventHandlerRT<?>> handlers) {
-        this.handlers = Objects.requireNonNull(handlers);
+    public void setHandlers(@NonNull List<? extends EventHandlerRT<?>> handlers) {
+        // ensure the list is unmodifiable by calling copyOf()
+        this.handlers = List.copyOf(Objects.requireNonNull(handlers));
     }
 
     @Override

--- a/Core/src/com/serotonin/m2m2/rt/event/type/DataPointEventType.java
+++ b/Core/src/com/serotonin/m2m2/rt/event/type/DataPointEventType.java
@@ -35,7 +35,7 @@ public class DataPointEventType extends EventType {
 
     public DataPointEventType(DataPointVO dataPoint, AbstractPointEventDetectorVO eventDetector) {
         this.dataPointId = dataPoint.getId();
-        this.pointEventDetectorId = eventDetector.getId();
+        this.pointEventDetectorId = eventDetector == null ? 0 : eventDetector.getId();
         supplyReference1(() -> {
             return dataPoint;
         });

--- a/Core/src/com/serotonin/m2m2/rt/publish/AttributePublishQueue.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/AttributePublishQueue.java
@@ -1,89 +1,38 @@
 /*
- * Copyright (C) 2021 Radix IoT LLC. All rights reserved.
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
  */
+
 package com.serotonin.m2m2.rt.publish;
 
-import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.locks.ReentrantLock;
 
 import com.serotonin.m2m2.vo.publish.PublishedPointVO;
 
 /**
- * 
- * This queue is thread safe and backed by an ordered map of attributes to PublishedPointVO
- * 
  * @author Terry Packer
- *
+ * @author Jared Wiltshire
  */
-public class AttributePublishQueue<T extends PublishedPointVO> {
-
-    //Create a fair lock in effort to ensure ordering is kept
-    protected final ReentrantLock lock = new ReentrantLock(true);
-    protected final LinkedHashMap<Integer, PublishQueueEntry<T, Map<String, Object>>> attributesToBePublished;
-    
-    public AttributePublishQueue(int initialSize) {
-        this.attributesToBePublished = new LinkedHashMap<>(initialSize);
-    }
-
-    public AttributePublishQueue() {
-        this.attributesToBePublished = new LinkedHashMap<>();
-    }
+public interface AttributePublishQueue<T extends PublishedPointVO> {
+    /**
+     * Add attributes to be published.  There is only 1 entry for attributes per published point and the order is
+     * insertion based.
+     */
+    void add(T vo, Map<String, Object> value);
 
     /**
-     * Add attributes to be published.  There is only 1 entry for attributes per published point and the order is 
-     *   insertion based.
+     * Re-add the attributes to the queue if an entry for this vo does not already exist.
+     * This is used when the attributes didn't get published and potentially an attribute update
+     * happened while they were out of this structure.
      */
-    public void add(T vo, Map<String,Object> value) {
-        lock.lock();
-        try{
-            attributesToBePublished.put(vo.getDataPointId(), new PublishQueueEntry<T, Map<String, Object>>(vo, value));
-        }finally {
-            lock.unlock();
-        }
-    }
-    
-    /**
-     * Re-add the attributes to the queue if an entry for this vo does not already exist.  
-     *  This is used when the attributes didn't get published and potentially an attribute update
-     *  happened while they were out of this structure.
-     *
-     */
-    public void attributePublishFailed(PublishQueueEntry<T,Map<String,Object>> entry) {
-        lock.lock();
-        try{
-            attributesToBePublished.computeIfAbsent(entry.getVo().getDataPointId(), k -> entry);
-        }finally {
-            lock.unlock();
-        }
-    }
+    void attributePublishFailed(PublishQueueEntry<T, Map<String, Object>> entry);
 
     /**
      * Remove the next item from the queue
      */
-    public PublishQueueEntry<T,Map<String,Object>> next() {
-        lock.lock();
-        try{
-            Iterator<Integer> it = attributesToBePublished.keySet().iterator();
-            if(it.hasNext()) {
-                return attributesToBePublished.remove(it.next());
-            }else
-                return null;
-        }finally {
-            lock.unlock();
-        }
-    }
-    
+    PublishQueueEntry<T, Map<String, Object>> next();
+
     /**
      * Empty the queue entirely
      */
-    public void clear() {
-        lock.lock();
-        try{
-            attributesToBePublished.clear();
-        }finally {
-            lock.unlock();
-        }
-    }
+    void clear();
 }

--- a/Core/src/com/serotonin/m2m2/rt/publish/AttributePublishQueueImpl.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/AttributePublishQueueImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 Radix IoT LLC. All rights reserved.
+ */
+package com.serotonin.m2m2.rt.publish;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.serotonin.m2m2.vo.publish.PublishedPointVO;
+
+/**
+ * 
+ * This queue is thread safe and backed by an ordered map of attributes to PublishedPointVO
+ * 
+ * @author Terry Packer
+ *
+ */
+public class AttributePublishQueueImpl<T extends PublishedPointVO> implements AttributePublishQueue<T> {
+
+    //Create a fair lock in effort to ensure ordering is kept
+    protected final ReentrantLock lock = new ReentrantLock(true);
+    protected final LinkedHashMap<Integer, PublishQueueEntry<T, Map<String, Object>>> attributesToBePublished = new LinkedHashMap<>();
+
+    @Override
+    public void add(T vo, Map<String, Object> value) {
+        lock.lock();
+        try {
+            attributesToBePublished.put(vo.getDataPointId(), new PublishQueueEntry<>(vo, value));
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    @Override
+    public void attributePublishFailed(PublishQueueEntry<T, Map<String, Object>> entry) {
+        lock.lock();
+        try {
+            attributesToBePublished.putIfAbsent(entry.getVo().getDataPointId(), entry);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public PublishQueueEntry<T,Map<String,Object>> next() {
+        lock.lock();
+        try {
+            Iterator<Integer> it = attributesToBePublished.keySet().iterator();
+            if (it.hasNext()) {
+                return attributesToBePublished.remove(it.next());
+            } else {
+                return null;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    @Override
+    public void clear() {
+        lock.lock();
+        try {
+            attributesToBePublished.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/Core/src/com/serotonin/m2m2/rt/publish/PublishQueue.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/PublishQueue.java
@@ -65,7 +65,7 @@ public interface PublishQueue<T extends PublishedPointVO, V> {
     /**
      * Clears the queue, removing all entries.
      */
-    void removeAll();
+    void clear();
 
     /**
      * @return number of items stored in the queue

--- a/Core/src/com/serotonin/m2m2/rt/publish/PublishQueue.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/PublishQueue.java
@@ -1,139 +1,79 @@
 /*
- * Copyright (C) 2021 Radix IoT LLC. All rights reserved.
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
  */
+
 package com.serotonin.m2m2.rt.publish;
 
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.Collection;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 
-import com.infiniteautomation.mango.monitor.ValueMonitor;
-import com.serotonin.m2m2.Common;
-import com.serotonin.m2m2.i18n.TranslatableMessage;
 import com.serotonin.m2m2.vo.publish.PublishedPointVO;
-import com.serotonin.m2m2.vo.publish.PublisherVO;
 
 /**
- * 
- * @author Matthew Lohbihler
+ * @author Jared Wiltshire
  */
-public class PublishQueue<PUB extends PublisherVO, T extends PublishedPointVO, V> {
-    private static final Logger LOG = LoggerFactory.getLogger(PublishQueue.class);
-    private static final long SIZE_CHECK_DELAY = 5000;
+public interface PublishQueue<T extends PublishedPointVO, V> {
+    /**
+     * Add an entry to the tail of the queue.
+     *
+     * @param vo the published point to which this entry belongs
+     * @param item the point value/attribute for the published point
+     */
+    void add(T vo, V item);
 
-    //Metrics
-    public static final String QUEUE_SIZE_MONITOR_ID = "com.serotonin.m2m2.rt.publish.QUEUE_SIZE_MONITOR_";
+    /**
+     * Add entries to the tail of the queue.
+     *
+     * @param vo the published point to which these entries belong
+     * @param items the point values/attributes for the published point
+     */
+    void add(T vo, Collection<V> items);
 
-    //Monitors
-    final ValueMonitor<Integer> queueSizeMonitor;
+    /**
+     * Retrieve a single entry from the head of the queue without removing it (peek).
+     *
+     * @return entry from head of queue, or null if the queue is empty.
+     */
+    @Nullable
+    PublishQueueEntry<T, V> next();
 
-    protected final ConcurrentLinkedQueue<PublishQueueEntry<T, V>> queue = new ConcurrentLinkedQueue<PublishQueueEntry<T, V>>();
-    private final PublisherRT<PUB, T, ? extends SendThread> owner;
-    private final int warningSize;
-    private final int dewarningSize;
-    private final int discardSize;
-    private boolean warningActive = false;
-    private long lastSizeCheck;
+    /**
+     * Retrieves multiple entries from the head of the queue without removing them (peek).
+     *
+     * @param max maximum number of entries to retrieve
+     * @throws IllegalArgumentException if max is less than 0
+     * @return list of entries from head of queue
+     */
+    List<PublishQueueEntry<T, V>> get(int max);
 
-    public PublishQueue(PublisherRT<PUB, T, ? extends SendThread> owner, int warningSize, int discardSize) {
-        this.owner = owner;
-        this.warningSize = warningSize;
-        this.dewarningSize = (int) (warningSize * 0.9); // Deactivate the size warning at 90% of the warning size.
-        this.discardSize = discardSize;
-        this.queueSizeMonitor = Common.MONITORED_VALUES.<Integer>create(QUEUE_SIZE_MONITOR_ID + this.owner.getVo().getXid())
-                .name(new TranslatableMessage("publisher.monitor.QUEUE_SIZE_MONITOR_ID", this.owner.getVo().getName())).build();
+    /**
+     * Removes a single entry from the queue (by identity).
+     *
+     * @param entry entry to remove
+     */
+    void remove(PublishQueueEntry<T, V> entry);
 
-    }
+    /**
+     * Removes all the specified entries from the queue (by identity).
+     *
+     * @param entries entries to be removed
+     */
+    void removeAll(Collection<PublishQueueEntry<T, V>> entries);
 
-    public void add(T vo, V pvt) {
-        queue.add(new PublishQueueEntry<T, V>(vo, pvt));
-        sizeCheck();
-    }
+    /**
+     * Clears the queue, removing all entries.
+     */
+    void removeAll();
 
-    public void add(T vo, List<V> pvts) {
-        for (V pvt : pvts)
-            queue.add(new PublishQueueEntry<T, V>(vo, pvt));
-        sizeCheck();
-    }
+    /**
+     * @return number of items stored in the queue
+     */
+    int getSize();
 
-    public PublishQueueEntry<T,V> next() {
-        return queue.peek();
-    }
-
-    public List<PublishQueueEntry<T,V>> get(int max) {
-        if (queue.isEmpty())
-            return List.of();
-
-        Iterator<PublishQueueEntry<T,V>> iter = queue.iterator();
-        List<PublishQueueEntry<T,V>> result = new ArrayList<>(max);
-        while (iter.hasNext() && result.size() < max)
-            result.add(iter.next());
-
-        return result;
-    }
-
-    public void remove(PublishQueueEntry<T,V> e) {
-        queue.remove(e);
-        sizeCheck();
-    }
-
-    public void removeAll(List<PublishQueueEntry<T,V>> list) {
-        queue.removeAll(list);
-        sizeCheck();
-    }
-    
-    public void removeAll() {
-    	queue.clear();
-    }
-
-    public int getSize() {
-        return queue.size();
-    }
-
-    private void sizeCheck() {
-        long now = Common.timer.currentTimeMillis();
-        if (lastSizeCheck + SIZE_CHECK_DELAY < now) {
-            lastSizeCheck = now;
-            int size = queue.size();
-            queueSizeMonitor.setValue(size);
-            synchronized (owner) {
-                if (size > discardSize) {
-                	try {
-                		for (int i = discardSize; i < size; i++)
-                			queue.remove();
-                	} catch(NoSuchElementException e) {
-                		//Queue is emptied, nothing to do
-                	}
-                	
-                    LOG.warn("Publisher queue " + owner.getVo().getName() + " discarded " + (size - discardSize)
-                            + " entries");
-                }
-
-                if (warningActive) {
-                    if (size <= dewarningSize) {
-                        owner.deactivateQueueSizeWarningEvent();
-                        warningActive = false;
-                    }
-                }
-                else {
-                    if (size > warningSize) {
-                        owner.fireQueueSizeWarningEvent();
-                        warningActive = true;
-                    }
-                }
-            }
-        }
-    }
-
-    public void terminate() {
-        Common.MONITORED_VALUES.remove(this.queueSizeMonitor.getId());
-        if(!queue.isEmpty()){
-            LOG.debug("Publisher " + owner.readableIdentifier() + " terminated with a non-empty queue.");
-        }
-    }
+    /**
+     * Called when the publisher which owns this queue is terminated.
+     */
+    void terminate();
 }

--- a/Core/src/com/serotonin/m2m2/rt/publish/PublishQueue.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/PublishQueue.java
@@ -67,10 +67,10 @@ public class PublishQueue<PUB extends PublisherVO, T extends PublishedPointVO, V
 
     public List<PublishQueueEntry<T,V>> get(int max) {
         if (queue.isEmpty())
-            return null;
+            return List.of();
 
         Iterator<PublishQueueEntry<T,V>> iter = queue.iterator();
-        List<PublishQueueEntry<T,V>> result = new ArrayList<PublishQueueEntry<T,V>>(max);
+        List<PublishQueueEntry<T,V>> result = new ArrayList<>(max);
         while (iter.hasNext() && result.size() < max)
             result.add(iter.next());
 

--- a/Core/src/com/serotonin/m2m2/rt/publish/PublishQueueImpl.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/PublishQueueImpl.java
@@ -95,7 +95,7 @@ public class PublishQueueImpl<T extends PublishedPointVO, V> implements PublishQ
     }
     
     @Override
-    public void removeAll() {
+    public void clear() {
     	queue.clear();
     }
 

--- a/Core/src/com/serotonin/m2m2/rt/publish/PublishQueueImpl.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/PublishQueueImpl.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2021 Radix IoT LLC. All rights reserved.
+ */
+package com.serotonin.m2m2.rt.publish;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+
+import com.infiniteautomation.mango.monitor.ValueMonitor;
+import com.serotonin.m2m2.Common;
+import com.serotonin.m2m2.i18n.TranslatableMessage;
+import com.serotonin.m2m2.vo.publish.PublishedPointVO;
+
+/**
+ * 
+ * @author Matthew Lohbihler
+ */
+public class PublishQueueImpl<T extends PublishedPointVO, V> implements PublishQueue<T, V> {
+    private static final Logger LOG = LoggerFactory.getLogger(PublishQueueImpl.class);
+    private static final long SIZE_CHECK_DELAY = 5000;
+
+    //Metrics
+    public static final String QUEUE_SIZE_MONITOR_ID = "com.serotonin.m2m2.rt.publish.QUEUE_SIZE_MONITOR_";
+
+    //Monitors
+    final ValueMonitor<Integer> queueSizeMonitor;
+
+    protected final ConcurrentLinkedQueue<PublishQueueEntry<T, V>> queue = new ConcurrentLinkedQueue<>();
+    private final PublisherRT<?, T, ?> owner;
+    private final int warningSize;
+    private final int dewarningSize;
+    private final int discardSize;
+    private boolean warningActive = false;
+    private long lastSizeCheck;
+
+    public PublishQueueImpl(PublisherRT<?, T, ?> owner, int warningSize, int discardSize) {
+        this.owner = owner;
+        this.warningSize = warningSize;
+        this.dewarningSize = (int) (warningSize * 0.9); // Deactivate the size warning at 90% of the warning size.
+        this.discardSize = discardSize;
+        this.queueSizeMonitor = Common.MONITORED_VALUES.<Integer>create(QUEUE_SIZE_MONITOR_ID + this.owner.getVo().getXid())
+                .name(new TranslatableMessage("publisher.monitor.QUEUE_SIZE_MONITOR_ID", this.owner.getVo().getName())).build();
+    }
+
+    @Override
+    public void add(T vo, V item) {
+        queue.add(new PublishQueueEntry<>(vo, item));
+        sizeCheck();
+    }
+
+    @Override
+    public void add(T vo, Collection<V> items) {
+        for (V pvt : items)
+            queue.add(new PublishQueueEntry<>(vo, pvt));
+        sizeCheck();
+    }
+
+    @Override
+    public @Nullable PublishQueueEntry<T,V> next() {
+        return queue.peek();
+    }
+
+    @Override
+    public List<PublishQueueEntry<T,V>> get(int max) {
+        if (max < 0) throw new IllegalArgumentException();
+        if (max == 0 || queue.isEmpty())
+            return List.of();
+
+        Iterator<PublishQueueEntry<T,V>> iter = queue.iterator();
+        List<PublishQueueEntry<T,V>> result = new ArrayList<>(max);
+        while (iter.hasNext() && result.size() < max)
+            result.add(iter.next());
+
+        return result;
+    }
+
+    @Override
+    public void remove(PublishQueueEntry<T, V> entry) {
+        queue.remove(entry);
+        sizeCheck();
+    }
+
+    @Override
+    public void removeAll(Collection<PublishQueueEntry<T, V>> entries) {
+        queue.removeAll(entries);
+        sizeCheck();
+    }
+    
+    @Override
+    public void removeAll() {
+    	queue.clear();
+    }
+
+    @Override
+    public int getSize() {
+        return queue.size();
+    }
+
+    private void sizeCheck() {
+        long now = Common.timer.currentTimeMillis();
+        if (lastSizeCheck + SIZE_CHECK_DELAY < now) {
+            lastSizeCheck = now;
+            int size = queue.size();
+            queueSizeMonitor.setValue(size);
+            synchronized (owner) {
+                if (size > discardSize) {
+                	try {
+                		for (int i = discardSize; i < size; i++)
+                			queue.remove();
+                	} catch(NoSuchElementException e) {
+                		//Queue is emptied, nothing to do
+                	}
+                	
+                    LOG.warn("Publisher queue " + owner.getVo().getName() + " discarded " + (size - discardSize)
+                            + " entries");
+                }
+
+                if (warningActive) {
+                    if (size <= dewarningSize) {
+                        owner.deactivateQueueSizeWarningEvent();
+                        warningActive = false;
+                    }
+                }
+                else {
+                    if (size > warningSize) {
+                        owner.fireQueueSizeWarningEvent();
+                        warningActive = true;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void terminate() {
+        Common.MONITORED_VALUES.remove(this.queueSizeMonitor.getId());
+        if(!queue.isEmpty()){
+            LOG.debug("Publisher " + owner.readableIdentifier() + " terminated with a non-empty queue.");
+        }
+    }
+}

--- a/Core/src/com/serotonin/m2m2/rt/publish/PublisherRT.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/PublisherRT.java
@@ -294,6 +294,15 @@ abstract public class PublisherRT<T extends PublisherVO, POINT extends Published
      */
     protected void terminateImpl() { }
 
+    /**
+     * Call terminate on the queue.
+     */
+    protected void terminateQueue() {
+        if (queue != null) {
+            queue.terminate();
+        }
+    }
+
     @Override
     public final synchronized void initialize(boolean safe) {
         ensureState(ILifecycleState.PRE_INITIALIZE);
@@ -389,7 +398,7 @@ abstract public class PublisherRT<T extends PublisherVO, POINT extends Published
 
         try {
             // Terminate the queue
-            queue.terminate();
+            terminateQueue();
         } catch (Exception e) {
             log.error("Failed to terminate queue for " + readableIdentifier(), e);
         }

--- a/Core/src/com/serotonin/m2m2/rt/publish/PublisherRT.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/PublisherRT.java
@@ -84,7 +84,7 @@ abstract public class PublisherRT<T extends PublisherVO, POINT extends Published
      */
     protected final Collection<PublishedPointRT<POINT>> publishedPoints = Collections.unmodifiableCollection(publishedPointsMap.values());
 
-    protected final PublishQueue<T, POINT, PointValueTime> queue;
+    protected final PublishQueue<POINT, PointValueTime> queue;
     protected final AttributePublishQueue<POINT> attributesChangedQueue;
     private boolean pointEventActive;
     private volatile Thread jobThread;
@@ -108,8 +108,8 @@ abstract public class PublisherRT<T extends PublisherVO, POINT extends Published
         return vo.getId();
     }
 
-    protected PublishQueue<T, POINT, PointValueTime> createPublishQueue(PublisherVO vo) {
-        return new PublishQueue<>(this, vo.getCacheWarningSize(), vo.getCacheDiscardSize());
+    protected PublishQueue<POINT, PointValueTime> createPublishQueue(PublisherVO vo) {
+        return new PublishQueueImpl<>(this, vo.getCacheWarningSize(), vo.getCacheDiscardSize());
     }
 
     protected AttributePublishQueue<POINT> createAttirbutesChangedQueue() {
@@ -478,6 +478,11 @@ abstract public class PublisherRT<T extends PublisherVO, POINT extends Published
     @Override
     public String getTaskId() {
         return "PUB-" + vo.getXid();
+    }
+
+    @Override
+    public int getQueueSize() {
+        return queue.getSize();
     }
 
     @Override

--- a/Core/src/com/serotonin/m2m2/rt/publish/PublisherRT.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/PublisherRT.java
@@ -167,7 +167,7 @@ abstract public class PublisherRT<T extends PublisherVO, POINT extends Published
         }
     }
 
-    void publish(POINT vo, PointValueTime newValue) {
+    protected void publish(POINT vo, PointValueTime newValue) {
         queue.add(vo, newValue);
 
         synchronized (sendThread) {
@@ -175,7 +175,7 @@ abstract public class PublisherRT<T extends PublisherVO, POINT extends Published
         }
     }
 
-    public void publish(POINT vo, List<PointValueTime> newValues) {
+    protected void publish(POINT vo, List<PointValueTime> newValues) {
         queue.add(vo, newValues);
 
         synchronized (sendThread) {

--- a/Core/src/com/serotonin/m2m2/rt/publish/mock/MockPublisherRT.java
+++ b/Core/src/com/serotonin/m2m2/rt/publish/mock/MockPublisherRT.java
@@ -4,8 +4,6 @@
 
 package com.serotonin.m2m2.rt.publish.mock;
 
-import com.serotonin.m2m2.rt.dataImage.PointValueTime;
-import com.serotonin.m2m2.rt.publish.PublishQueue;
 import com.serotonin.m2m2.rt.publish.PublisherRT;
 import com.serotonin.m2m2.rt.publish.SendThread;
 import com.serotonin.m2m2.vo.publish.mock.MockPublishedPointVO;
@@ -30,11 +28,6 @@ public class MockPublisherRT extends PublisherRT<MockPublisherVO, MockPublishedP
     public void terminateImpl() {
 
     }
-
-    PublishQueue<MockPublisherVO, MockPublishedPointVO, PointValueTime> getPublishQueue() {
-        return queue;
-    }
-
 
     class MockSendThread extends SendThread {
 

--- a/docker-image/pom.xml
+++ b/docker-image/pom.xml
@@ -12,6 +12,8 @@
     <packaging>pom</packaging>
     <properties>
         <docker.repository>ghcr.io/mangoautomation/mango</docker.repository>
+        <docker.tag>${project.version}</docker.tag>
+        <docker.skipNightly>false</docker.skipNightly>
     </properties>
     <build>
         <plugins>
@@ -50,6 +52,7 @@
                             <goal>push</goal>
                         </goals>
                         <configuration>
+                            <skip>${docker.skipNightly}</skip>
                             <tag>nightly</tag>
                             <skipDockerInfo>true</skipDockerInfo>
                         </configuration>
@@ -58,7 +61,7 @@
                 <configuration>
                     <repository>${docker.repository}</repository>
                     <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
-                    <tag>${project.version}</tag>
+                    <tag>${docker.tag}</tag>
                     <buildArgs>
                         <BUNDLE_ZIP>maven-target/dependency/mango-bundle-${project.version}.zip</BUNDLE_ZIP>
                     </buildArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <surefire.fork.count>1</surefire.fork.count>
         <grpc.version>1.52.1</grpc.version>
         <protobuf.version>3.21.12</protobuf.version>
+        <chronicle.version>2.24ea18</chronicle.version>
     </properties>
     <organization>
         <name>Radix IoT, LLC</name>
@@ -461,4 +462,15 @@
             <url>https://maven.mangoautomation.net/repository/ias-release/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>net.openhft</groupId>
+                <artifactId>chronicle-bom</artifactId>
+                <version>${chronicle.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <resilience4j.version>1.7.1</resilience4j.version>
         <MA_HOME>${env.MA_HOME}</MA_HOME>
         <surefire.fork.count>1</surefire.fork.count>
+        <grpc.version>1.52.1</grpc.version>
+        <protobuf.version>3.21.12</protobuf.version>
     </properties>
     <organization>
         <name>Radix IoT, LLC</name>
@@ -160,6 +162,13 @@
                 <directory>resources-test</directory>
             </testResource>
         </testResources>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -307,6 +316,26 @@
                 <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>3.1.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.xolstice.maven.plugins</groupId>
+                    <artifactId>protobuf-maven-plugin</artifactId>
+                    <version>0.6.1</version>
+                    <configuration>
+                        <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                        <pluginId>grpc-java</pluginId>
+                        <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                        <protoSourceRoot>proto</protoSourceRoot>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>compile</id>
+                            <goals>
+                                <goal>compile</goal>
+                                <goal>compile-custom</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
# Jira tickets
- [Add gRPC Support to Mango Core](https://radixiot.atlassian.net/browse/PI-1630)

# Related PRs
Please see https://github.com/MangoAutomation/ma-modules-private/pull/465 for full detail on the related work.

# Description of work

- Add Maven protobuf/grpc plugin for compiling protobuf files
- Add protobuf files with messages describing data points, point values and events
- Add gRPC server to Mango Core with configurable TLS/mTLS support
- Other modules/core may in the future use the same gRPC port to expose more services
- gRPC is configured to use TLS encryption via mango.properties file, the server may also authenticate the clients via mTLS
- Add way to register a universal event "handler" (really a listener interface) that receives all events
- Extract interfaces from PublisherQueue and AttributePublishQueue
- Support null event detectors in DataPointEventType
- Make the Docker tag configurable via a Maven property
- Add the Chronicle BOM, Chronicle Map module will now use version 2.24ea18 (**needs testing**)
- MySQL connector was updated to version 8.0.32 as the older version had an incompatible protobuf dependency (**needs testing**)