### PR TITLE
[PI-1689] Add gRPC interceptor to set the Spring security context and map exceptions

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -756,6 +756,11 @@ with Springfox 3.
             <version>${grpc.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-services</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>annotations-api</artifactId>
             <version>6.0.53</version>

--- a/Core/resources/mango.properties
+++ b/Core/resources/mango.properties
@@ -633,6 +633,8 @@ oauth2.client.default.userMapping.roles.add=
 grpc.server.enabled=true
 # gRPC server TCP port
 grpc.server.port=9090
+# Enable gRPC reflection service
+grpc.server.enableReflection=false
 # Server X.509 certificate, including full certificate chain. Path to file (in PEM format).
 #grpc.server.certChain=
 # Server private key. Path to file (in PEM format).

--- a/Core/src/com/infiniteautomation/mango/spring/grpc/AuthenticationServerCallListener.java
+++ b/Core/src/com/infiniteautomation/mango/spring/grpc/AuthenticationServerCallListener.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+package com.infiniteautomation.mango.spring.grpc;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.ServerCall.Listener;
+
+/**
+ * Sets the authentication into the Spring Security context when calling gRPC service methods.
+ *
+ * @author Jared Wiltshire
+ */
+public class AuthenticationServerCallListener<ReqT> extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
+
+    private final Authentication authentication;
+
+    public AuthenticationServerCallListener(Listener<ReqT> listener, Authentication authentication) {
+        super(listener);
+        this.authentication = authentication;
+    }
+
+    private void withAuthentication(Runnable command) {
+        SecurityContext original = SecurityContextHolder.getContext();
+        try {
+            SecurityContext newContext = SecurityContextHolder.createEmptyContext();
+            newContext.setAuthentication(authentication);
+            SecurityContextHolder.setContext(newContext);
+            command.run();
+        } finally {
+            SecurityContext emptyContext = SecurityContextHolder.createEmptyContext();
+            if (emptyContext.equals(original)) {
+                SecurityContextHolder.clearContext();
+            } else {
+                SecurityContextHolder.setContext(original);
+            }
+        }
+    }
+
+    @Override
+    public void onMessage(ReqT message) {
+        withAuthentication(() -> super.onMessage(message));
+    }
+
+    @Override
+    public void onHalfClose() {
+        withAuthentication(super::onHalfClose);
+    }
+
+    @Override
+    public void onCancel() {
+        withAuthentication(super::onCancel);
+    }
+
+    @Override
+    public void onComplete() {
+        withAuthentication(super::onComplete);
+    }
+
+    @Override
+    public void onReady() {
+        withAuthentication(super::onReady);
+    }
+}

--- a/Core/src/com/infiniteautomation/mango/spring/grpc/ErrorHandlingInterceptor.java
+++ b/Core/src/com/infiniteautomation/mango/spring/grpc/ErrorHandlingInterceptor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+package com.infiniteautomation.mango.spring.grpc;
+
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.StatusRuntimeException;
+
+/**
+ * Catches exceptions from service methods and downstream interceptors and handles them by closing the server call with
+ * an appropriate status and metadata.
+ *
+ * @author Jared Wiltshire
+ */
+public class ErrorHandlingInterceptor implements ServerInterceptor {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final Function<Exception, StatusRuntimeException> errorHandler;
+
+    protected ErrorHandlingInterceptor(Function<Exception, StatusRuntimeException> errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    private <ReqT, RespT> void handleError(ServerCall<ReqT, RespT> call, Exception e) {
+        log.trace("Handling error", e);
+        var statusRuntimeException = errorHandler.apply(e);
+        var trailers = statusRuntimeException.getTrailers();
+        call.close(statusRuntimeException.getStatus(), trailers != null ? trailers : new Metadata());
+    }
+
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        try {
+            return new SimpleForwardingServerCallListener<>(next.startCall(call, headers)) {
+
+                @Override
+                public void onMessage(ReqT message) {
+                    try {
+                        super.onMessage(message);
+                    } catch (Exception e) {
+                        handleError(call, e);
+                    }
+                }
+
+                @Override
+                public void onHalfClose() {
+                    try {
+                        super.onHalfClose();
+                    } catch (Exception e) {
+                        handleError(call, e);
+                    }
+                }
+            };
+        } catch (Exception e) {
+            handleError(call, e);
+            return new Listener<>() {};
+        }
+    }
+
+}

--- a/Core/src/com/infiniteautomation/mango/spring/grpc/FixedAuthenticationInterceptor.java
+++ b/Core/src/com/infiniteautomation/mango/spring/grpc/FixedAuthenticationInterceptor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+package com.infiniteautomation.mango.spring.grpc;
+
+import org.springframework.security.core.Authentication;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+/**
+ * Interceptor that sets a fixed {@link Authentication} object into the Spring Security context.
+ *
+ * @author Jared Wiltshire
+ */
+public class FixedAuthenticationInterceptor implements ServerInterceptor {
+
+    private final Authentication authentication;
+
+    public FixedAuthenticationInterceptor(Authentication authentication) {
+        this.authentication = authentication;
+    }
+
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        return new AuthenticationServerCallListener<>(next.startCall(call, headers), authentication);
+    }
+}

--- a/Core/src/com/infiniteautomation/mango/spring/grpc/GrpcServerLifecycle.java
+++ b/Core/src/com/infiniteautomation/mango/spring/grpc/GrpcServerLifecycle.java
@@ -36,7 +36,6 @@ import io.grpc.TlsServerCredentials;
 import io.grpc.TlsServerCredentials.ClientAuth;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.protobuf.services.ProtoReflectionService;
-import io.grpc.util.TransmitStatusRuntimeExceptionInterceptor;
 
 /**
  * @author Jared Wiltshire
@@ -98,7 +97,6 @@ public class GrpcServerLifecycle {
         var builder = inProcessServer != null ?
                 InProcessServerBuilder.forName(inProcessServer) :
                 Grpc.newServerBuilderForPort(port, serverCredentials);
-        builder.intercept(TransmitStatusRuntimeExceptionInterceptor.instance());
 
         // interceptors run in the reverse order of which they were added, reverse the list so the highest priority
         // (via Order annotation, or Ordered interface) interceptor runs first.

--- a/Core/src/com/infiniteautomation/mango/spring/grpc/InterceptorFor.java
+++ b/Core/src/com/infiniteautomation/mango/spring/grpc/InterceptorFor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ */
+
+package com.infiniteautomation.mango.spring.grpc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.grpc.BindableService;
+
+/**
+ * Annotation which can be applied to a {@link io.grpc.ServerInterceptor} in order to limit its scope to a set of
+ * {@link BindableService}. Any interceptor which does not have this annotation will be applied globally to all services.
+ *
+ * @author Jared Wiltshire
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InterceptorFor {
+    Class<? extends BindableService>[] value();
+}


### PR DESCRIPTION
# Jira tickets
- [Add gRPC interceptor to set the Spring security context and map exceptions](https://radixiot.atlassian.net/browse/PI-1689)

# Related PRs

- https://github.com/MangoAutomation/ma-modules-private/pull/494

# Description of work

- Add property to enable gRPC reflection
- Remove `TransmitStatusRuntimeExceptionInterceptor` from default interceptors
- Add annotation which restricts an interceptor bean to a set of gRPC services (otherwise interceptor beans are global)
- Add several interceptor base classes which can be used in modules