### PR TITLE
RAD-2735: Upgrade commons text from version 1.9 to 1.10.0 as vulnerab…

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
RAD-2735: Upgrade commons text from version 1.9 to 1.10.0 as vulnerability is fixed on this latest version. This ticket was created  by depndabot job so this commons-text 1.9 contains vulnerabilities that are fixed on version 1.10.0.