### PR TITLE
RAD-2568-print-environment-variables

### DIFF
--- a/Core/bin/README.md
+++ b/Core/bin/README.md
@@ -1,0 +1,71 @@
+Scripts
+==========
+
+Scripts modules first of all loads the environment variables by the `getenv.sh` script. Some of the most important variables that are needed are:
+
+- mango_paths_data
+- mango_config
+
+Mainly this variables specify the core for mango, where the source code and libraries are; as well as the data base files. All of them are properly known if Mango was set up by an installer, whenever we run a start_mango.sh all required variables must be figured out by this `getenv.sh` if the installetion was done like that.
+
+Another important thing to consider is that we also have a `mango.properties` file where we can change different values; normally this file is populated with lots of variables commented and also it contains a description of each variable value.
+
+Also there are other variables that can be useful to declare in case of deployments of other actions, this variables are:
+
+- mango_paths_data
+- keystore
+- MA_KEYSTORE
+- MA_KEYSTORE_PASSWORD
+- MA_KEY_PASSWORD
+- MA_KEY_ALIAS
+
+It is important to know that if needed we can customized the value for this variables by setting the value in the `mango.properties`.
+
+Note: We need to make sure the values are properly defined as if not, default values will be considered. This is part of a workaround where we found that default values are taken, so we just need to make sure we are defining the right values for our variables. That it is why additionally some messages are added so at some point the user was able to look at the environment values considered. 
+
+So when running a script it is basic to validate that `mango_paths_home` is correct, it must be the path where we set the Mango installation in the installer. And also we need to check `mango_paths_data` that is where the data base files and sources will be allocated.
+
+The environment values should be printed something like this:
+
+
+
+`++ HOME environment variable is /Users/juan.garcia`
+
+`++ mango_paths_home is /Users/juan.garcia/opt/mango`
+
+`+++++ HOME and mango_paths_home are not the same so script may not work properly!! ++++`
+
+`+++++ Mango configuration found on /Users/juan.garcia/mango.properties`
+
+`++ mango_paths_data environment variable is /Users/juan.garcia/opt/mango/data`
+
+`++ mango_script_dir is /Users/juan.garcia/opt/mango/bin`
+
+`++ mango_paths_data is /Users/juan.garcia/opt/mango/data`
+
+`++ keystore variable populated with mango.properties file property ssl.keystore.location`
+
+`++++++ MA_KEYSTORE environment variable populated with default value keystore.p12 as file /Users/juan.garcia/opt/mango/data/keystore.p12 was not found.`
+
+`+++++++ MA_KEYSTORE_PASSWORD environment variable populated with default value freetextpassword`
+
+`++ MA_KEY_PASSWORD environment variable populated with mango.properties file property ssl.key.password`
+
+`+++++ MA_KEY_ALIAS environment variable populated with default value mango`
+
+So the values of course will be loaded from properties file `mango.properties` in the following order:
+
+1- mango_config
+
+2- mango_paths_data/mango.properties
+
+3- mango_paths_data/env.properties
+
+4- HOME/mango.properties
+
+5- mango_paths_home/env.properties
+
+6- mango_paths_home/overrides/properties/env.properties
+
+So if you are facing issues by getting values that are not expected make sure you're following this order. Check your environment variables and mango properties.
+ 

--- a/Core/bin/getenv.sh
+++ b/Core/bin/getenv.sh
@@ -180,7 +180,12 @@ print_ma_keystore_value_source_message() {
   if [ "$1" = "$2" ]; then
     echo "++ MA_KEYSTORE used $1"
   else
-    echo "++++++ $3 default value $2 as file $1 was not found."
+    if [ -e $1 ]
+    then
+        echo "++++++ $3 default value $2"
+    else
+        echo "++++++ $3 default value $2 as file $1 was not found."
+    fi
   fi
 }
 

--- a/Core/bin/getenv.sh
+++ b/Core/bin/getenv.sh
@@ -257,6 +257,5 @@ if [ "$HOME" != "$mango_paths_home" ]; then
   echo "+++++ HOME and mango_paths_home are not the same so script may not work properly!! ++++"
 fi
 echo "+++++ Mango configuration found on $mango_config"
-echo "++ mango_paths_data environment variable is $mango_paths_data"
 echo "++ mango_script_dir is $mango_script_dir"
 echo "++ mango_paths_data is $mango_paths_data"

--- a/Core/bin/getenv.sh
+++ b/Core/bin/getenv.sh
@@ -35,20 +35,33 @@ resolve_path() {
 
 mango_keystore_properties() {
   if [ -z "$MA_KEYSTORE" ]; then
-    keystore="$(get_prop "ssl.keystore.location" "keystore.p12")"
+    keystoreMessage="keystore variable populated with"
+    keystoreDefault="keystore.p12"
+    keystoreProperty="ssl.keystore.location"
+    keystore="$(get_prop $keystoreProperty $keystoreDefault)"
+    print_value_source_message "$keystore" "$keystoreDefault" "$keystoreMessage" "$keystoreProperty"
     MA_KEYSTORE="$(resolve_path "$mango_paths_data" "$keystore")"
+    print_ma_keystore_value_source_message "$MA_KEYSTORE" "$keystore" "MA_KEYSTORE environment variable populated with"
   fi
 
   if [ -z "$MA_KEYSTORE_PASSWORD" ]; then
-    MA_KEYSTORE_PASSWORD="$(get_prop 'ssl.keystore.password' 'freetextpassword')"
+    maKeystoreMessage="MA_KEYSTORE_PASSWORD environment variable populated with"
+    maKeystorePasswordDefault="freetextpassword"
+    maKeystorePasswordProperty="ssl.keystore.password"
+    MA_KEYSTORE_PASSWORD="$(get_prop $maKeystorePasswordProperty maKeystorePasswordDefault)"
+    print_value_source_message "$MA_KEYSTORE_PASSWORD" "$maKeystorePasswordDefault" "$maKeystoreMessage" "$maKeystorePasswordProperty"
   fi
 
   if [ -z "$MA_KEY_PASSWORD" ]; then
-    MA_KEY_PASSWORD="$(get_prop 'ssl.key.password' "$MA_KEYSTORE_PASSWORD")"
+    maKeyMessage="MA_KEY_PASSWORD environment variable populated with"
+    maKeyPasswordProperty="ssl.key.password"
+    MA_KEY_PASSWORD="$(get_prop "$maKeyPasswordProperty" "$MA_KEYSTORE_PASSWORD")"
+    print_value_source_message "$MA_KEY_PASSWORD" "$MA_KEYSTORE_PASSWORD" "$maKeyMessage" "$maKeyPasswordProperty"
   fi
 
   if [ -z "$MA_KEY_ALIAS" ]; then
     MA_KEY_ALIAS=mango
+    echo "+++++ MA_KEY_ALIAS environment variable populated with default value mango"
   fi
 }
 
@@ -155,6 +168,22 @@ mango_stop() {
   rm -f "$mango_paths_pid_file"
 }
 
+print_value_source_message() {
+  if [ "$1" = "$2" ]; then
+    echo "++ $3 mango.properties file property $4"
+  else
+    echo "++++++ $3 default value $2"
+  fi
+}
+
+print_ma_keystore_value_source_message() {
+  if [ "$1" = "$2" ]; then
+    echo "++ MA_KEYSTORE used $1"
+  else
+    echo "++++++ $3 default value $2 as file $1 was not found."
+  fi
+}
+
 if [ -z "$mango_script_dir" ]; then
   err "This script is not intended to be executed directly"
 fi
@@ -221,3 +250,13 @@ mango_paths_data="$(resolve_path "$mango_paths_home" "$mango_paths_data")"
 mango_paths_pid_file="$(resolve_path "$mango_paths_data" "$mango_paths_pid_file")"
 [ -z "$mango_paths_start_options" ] && mango_paths_start_options="$(get_prop "paths.start.options" "$mango_paths_data/start-options.sh")"
 mango_paths_start_options="$(resolve_path "$mango_paths_data" "$mango_paths_start_options")"
+
+echo "++ HOME environment variable is $HOME"
+echo "++ mango_paths_home is $mango_paths_home"
+if [ "$HOME" != "$mango_paths_home" ]; then
+  echo "+++++ HOME and mango_paths_home are not the same so script may not work properly!! ++++"
+fi
+echo "+++++ Mango configuration found on $mango_config"
+echo "++ mango_paths_data environment variable is $mango_paths_data"
+echo "++ mango_script_dir is $mango_script_dir"
+echo "++ mango_paths_data is $mango_paths_data"


### PR DESCRIPTION
RAD-2568-print-environment-variables

After investigating the scripts it was determined that there is no issue with the scripts, however, they are tightly coupled to host machines' environmental variables.   So some users may not be aware of these requirements and be unaware of why the script is failing and in some cases where default values are being used they may not even know there is a problem. 


The suggestion to mitigate this:

For the getEnv.sh script is to provide feedback to the terminal when environmental variables are not found and default values are taken. 

Provide a README file to detail the environmental variables required. 

Script remains the same we are just printing some variables to guide user about the places where data would be. 

example:

```
++ HOME environment variable is /Users/juan.garcia
++ mango_paths_home is /Users/juan.garcia/opt/mango
+++++ HOME and mango_paths_home are not the same so script may not work properly!! ++++
+++++ Mango configuration found on /Users/juan.garcia/mango.properties
++ mango_paths_data environment variable is /Users/juan.garcia/opt/mango/data
++ mango_script_dir is /Users/juan.garcia/opt/mango/bin
++ mango_paths_data is /Users/juan.garcia/opt/mango/data
++ keystore variable populated with mango.properties file property ssl.keystore.location
++++++ MA_KEYSTORE environment variable populated with default value keystore.p12 as file /Users/juan.garcia/opt/mango/data/keystore.p12 was not found.
+++++++ MA_KEYSTORE_PASSWORD environment variable populated with default value freetextpassword
++ MA_KEY_PASSWORD environment variable populated with mango.properties file property ssl.key.password
+++++ MA_KEY_ALIAS environment variable populated with default value mango

```