### PR TITLE
#RAD-2271 added bug fix and tests for upserting db system settings for new modules - 5.0.x

### DIFF
--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -1,5 +1,6 @@
 *Version 4.5.1*
 * Improve performance for new points by setting the point value cache to an empty collection
+* Fixed a bug where system setting for db version would not get created/updated if it didn't exist before.
 
 *Version 4.5.0*
 * Add new rollup type Range (in period)

--- a/Core/resources-test/com/serotonin/m2m2/db/dao/systemsettingsaccessor/createTables-H2.sql
+++ b/Core/resources-test/com/serotonin/m2m2/db/dao/systemsettingsaccessor/createTables-H2.sql
@@ -1,0 +1,1 @@
+-- NOTE: This is purposely left empty for the test SystemSettingsAccessorTest

--- a/Core/src-test/com/serotonin/m2m2/db/dao/systemsettingsaccessor/SystemSettingsAccessorSchemaDefinitionTest.java
+++ b/Core/src-test/com/serotonin/m2m2/db/dao/systemsettingsaccessor/SystemSettingsAccessorSchemaDefinitionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 RadixIot LLC. All rights reserved.
+ *
+ */
+package com.serotonin.m2m2.db.dao.systemsettingsaccessor;
+
+import java.util.List;
+
+import org.jooq.Table;
+
+import com.infiniteautomation.mango.db.DefaultSchema;
+import com.serotonin.m2m2.module.DatabaseSchemaDefinition;
+
+public class SystemSettingsAccessorSchemaDefinitionTest extends DatabaseSchemaDefinition {
+
+    @Override
+    public String getNewInstallationCheckTableName() {
+        return "testmoduletable";
+    }
+
+    @Override
+    public List<Table<?>> getTablesForConversion() {
+        return DefaultSchema.DEFAULT_SCHEMA.getTables();
+    }
+
+    @Override
+    public String getUpgradePackage() {
+        return "com.serotonin.m2m2.db.dao.systemsettingsaccessor.upgrade";
+    }
+
+    @Override
+    public int getDatabaseSchemaVersion() {
+        return 1;
+    }
+}

--- a/Core/src-test/com/serotonin/m2m2/db/dao/systemsettingsaccessor/SystemSettingsAccessorTest.java
+++ b/Core/src-test/com/serotonin/m2m2/db/dao/systemsettingsaccessor/SystemSettingsAccessorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 RadixIot LLC. All rights reserved.
+ *
+ */
+
+package com.serotonin.m2m2.db.dao.systemsettingsaccessor;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.serotonin.m2m2.Common;
+import com.serotonin.m2m2.MangoTestBase;
+import com.serotonin.m2m2.db.dao.SystemSettingsDao;
+
+public class SystemSettingsAccessorTest extends MangoTestBase {
+    @BeforeClass
+    public static void setupModule() {
+        addModule("SysAccessorTestModule", new SystemSettingsAccessorSchemaDefinitionTest());
+        loadModules();
+    }
+
+    @Test
+    public void testInsertNewModules () {
+        SystemSettingsDao dao =  Common.getBean(SystemSettingsDao.class);
+        String version = dao.getValue("databaseSchemaVersion.SysAccessorTestModule");
+        assertEquals("1", version);
+    }
+}


### PR DESCRIPTION
This fixed the following: When a module is being installed for a first time, the systemAccessor class doesn’t have create capabilities.

More info at #[RAD-2271](https://radixiot.atlassian.net/browse/RAD-2271)

[RAD-2271]: https://radixiot.atlassian.net/browse/RAD-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ