### PR TITLE
#RAD-2315 corrected published points behavior via legacy publisher import - 5.0.x

### DIFF
--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -1,5 +1,6 @@
 *Version 4.5.1*
 * Improve performance for new points by setting the point value cache to an empty collection
+* Fix published points as disabled when importing a legacy publisher, defaults legacy points to enabled now.
 
 *Version 4.5.0*
 * Add new rollup type Range (in period)

--- a/Core/src-test/com/infiniteautomation/mango/spring/service/PublishedPointServiceTest.java
+++ b/Core/src-test/com/infiniteautomation/mango/spring/service/PublishedPointServiceTest.java
@@ -260,10 +260,20 @@ public class PublishedPointServiceTest extends AbstractVOServiceTest <PublishedP
         loadConfiguration(json);
         assertEquals(5, service.count());
 
+        //Check that legacy points got imported as enabled
+        for (PublishedPointVO pubLegacyPoint : service.list()) {
+            assertTrue(pubLegacyPoint.isEnabled());
+        }
+
         //Import publishedPoints for update (duplicate points).  This process
         // always inserts new points and can't update them since there is no XID field
         // on the import data's points array as it was not supported
         loadConfiguration(json);
         assertEquals(10, service.count());
+
+        //Check that legacy points got imported as enabled
+        for (PublishedPointVO pubLegacyPoint : service.list()) {
+            assertTrue(pubLegacyPoint.isEnabled());
+        }
     }
 }

--- a/Core/src/com/infiniteautomation/mango/emport/PublisherImporter.java
+++ b/Core/src/com/infiniteautomation/mango/emport/PublisherImporter.java
@@ -89,6 +89,7 @@ public class PublisherImporter extends Importer {
                                 DataPointVO dataPointVO = dataPointService.get(dataPointXid);
                                 PublishedPointVO point = vo.getDefinition().createPublishedPointVO(vo, dataPointVO);
                                 point.setName(dataPointVO.getName());
+                                point.setEnabled(true);
                                 ctx.getReader().readInto(point, jv.toJsonObject());
                                 point.setXid(publishedPointService.generateUniqueXid());
                                 publishedPointService.insert(point);


### PR DESCRIPTION
AC:

Importing new legacy publishers with points shows all points as enabled

Importing legacy publishers onto of an existing one should not alter the state of existing points.

Using the MockPublisherDefinition create a test that imports a legacy JSON file and confirm that the points are enabled.