### PR TITLE
Update mango.properties

### DIFF
--- a/Core/resources/mango.properties
+++ b/Core/resources/mango.properties
@@ -232,6 +232,10 @@ rest.temporaryResource.expirationPeriodType=HOURS
 rest.temporaryResource.timeoutPeriods=3
 rest.temporaryResource.timeoutPeriodType=HOURS
 
+# Defaults for System Action task and resource lifetime (Can override via endpoint parameter if supplied)
+rest.systemAction.expirationPeriods=1
+rest.systemAction.expirationPeriodType=WEEKS
+
 # Limits the rate at which an unauthenticated IP address can access the REST API
 # Defaults to an initial 10 request burst then 2 requests per 1 second thereafter
 rateLimit.rest.anonymous.enabled=true


### PR DESCRIPTION
New properties added for System Action task and resource lifetime (SystemActionTemporaryResource) rest.systemAction.expirationPeriods default is 1 and rest.systemAction.expirationPeriodType default is WEEKS