### PR TITLE
RAD-4040_4.5.1: Backporting RAD-4040 to 4.5.1

### DIFF
--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -3,6 +3,7 @@
 * Fixed a bug where system setting for db version would not get created/updated if it didn't exist before.
 * Fix published points as disabled when importing a legacy publisher, defaults legacy points to enabled now.
 * Upgrade commons-fileupload library version to 1.5 (mitigates CVE-2023-24998)
+* Fix to allow users to see comments for active alarms in real-time
 
 *Version 4.5.0*
 * Add new rollup type Range (in period)

--- a/Core/src/com/infiniteautomation/mango/spring/service/UserCommentService.java
+++ b/Core/src/com/infiniteautomation/mango/spring/service/UserCommentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Radix IoT LLC. All rights reserved.
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
  */
 
 package com.infiniteautomation.mango.spring.service;
@@ -51,39 +51,33 @@ public class UserCommentService extends AbstractVOService<UserCommentVO, UserCom
 
     @Override
     public boolean hasCreatePermission(PermissionHolder user, UserCommentVO vo) {
+        if (permissionService.hasAdminRole(user)) return true;
+
+        // When user has read permission for the reference object
         switch(vo.getCommentType()) {
             case UserCommentVO.TYPE_EVENT:
                 EventInstanceVO event = eventInstanceDao.get(vo.getReferenceId());
-                if(event != null) {
-                    return permissionService.hasPermission(user, event.getReadPermission());
-                }else {
-                    return permissionService.hasAdminRole(user);
-                }
+                return event != null && permissionService.hasPermission(user, event.getReadPermission());
             case UserCommentVO.TYPE_POINT:
                 return permissionService.hasDataPointReadPermission(user, vo.getReferenceId());
             case UserCommentVO.TYPE_JSON_DATA:
                 JsonDataVO json = jsonDataDao.get(vo.getReferenceId());
-                if(json != null) {
-                    return permissionService.hasPermission(user, json.getReadPermission());
-                }else {
-                    return permissionService.hasAdminRole(user);
-                }
+                return json != null && permissionService.hasPermission(user, json.getReadPermission());
             default:
-                return permissionService.hasAdminRole(user);
+                return false;
         }
     }
 
     @Override
     public boolean hasEditPermission(PermissionHolder user, UserCommentVO vo) {
-        if (permissionService.hasAdminRole(user))
-            return true;
-        else
-            return user.getUser() != null && vo.getUserId() == user.getUser().getId();
+        if (permissionService.hasAdminRole(user)) return true;
+        return user.getUser() != null && vo.getUserId() == user.getUser().getId();
     }
 
     @Override
     public boolean hasReadPermission(PermissionHolder user, UserCommentVO vo) {
-        return true;
+        // Same as create permission
+        return hasCreatePermission(user, vo);
     }
 
     @Override


### PR DESCRIPTION
## Description

In the Active Alarms page, the Compass LDAP users cannot see the Comments related to the new alarms that are appearing in real-time in the screen, so these changes introduce a fix to allow users to see comments for active alarms in real-time. Websocket tests have been added to be able to test it through node js tests
https://radixiot.atlassian.net/browse/RAD-4040

## Current behavior

In the Active Alarms page, the Compass LDAP users cannot see the Comments related to the new alarms that are appearing in real-time in the screen. But the Superadmin users can see Comments in real-time.

## Expected behavior
- Users can see the comments in real-time

## Changes
- Fix on UserCommentService and  UserCommentWebSocketHandler to allow users to see comments in real-time

## Resources
-

## Tests
NodeJS tests where added: 
- Websocket notifications for comments for DPs with role user and User with role user
- User should not have received any web socket messages

## Release Notes
Yes

