### PR TITLE
RAD-4754 Allow audit events when saving object without changes 4.5.x

### DIFF
--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -1,5 +1,6 @@
 *Version 4.5.2*
 * Add system settings for events export configuration
+* Allow audit events when saving object without changes
 
 *Version 4.5.1*
 * Improve performance for new points by setting the point value cache to an empty collection

--- a/Core/src/com/infiniteautomation/mango/spring/service/AuditEventService.java
+++ b/Core/src/com/infiniteautomation/mango/spring/service/AuditEventService.java
@@ -99,8 +99,8 @@ public class AuditEventService extends AbstractBasicVOService<AuditEventInstance
         JsonSerializableUtility scanner = new JsonSerializableUtility();
         try {
             context = scanner.findChanges(event.getFrom(), event.getVo());
-            if (context.size() == 0)
-                // If the object wasn't in fact changed, don't raise an event.
+            if (context.isEmpty() && event.getRaisingHolder() == PermissionHolder.SYSTEM_SUPERADMIN)
+                // If the object wasn't in fact changed, don't raise an event for system super admin.
                 return;
         } catch (IllegalAccessException | IllegalArgumentException
                 | InvocationTargetException | JsonException | IOException e) {


### PR DESCRIPTION
## Description

Backported changes for https://github.com/RadixIoT/mango/pull/350