### PR TITLE
RAD-4793 Fix editing user privilege escalation - Fluence

### DIFF
--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -1,9 +1,7 @@
-*Version 4.5.3*
-* Fix to allow users to remove roles from other users only when their permissions allows them to do so.
-
 *Version 4.5.2*
 * Add system settings for events export configuration
 * Allow audit events when saving object without changes
+* Fix to allow users to remove roles from other users only when their permissions allows them to do so.
 
 *Version 4.5.1*
 * Improve performance for new points by setting the point value cache to an empty collection

--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -1,3 +1,6 @@
+*Version 4.5.3*
+* Fix to allow users to remove roles from other users only when their permissions allows them to do so.
+
 *Version 4.5.2*
 * Add system settings for events export configuration
 * Allow audit events when saving object without changes

--- a/Core/resources/i18n.properties
+++ b/Core/resources/i18n.properties
@@ -2169,6 +2169,7 @@ validate.permission.null=Permission cannot be null
 validate.permission.cantAddRole=Cannot add/remove role {0}. You must hold a role to add or remove it.
 validate.permission.cantAddRoleSuperadminOnly=Cannot add/remove role {0}. You must have the superadmin role.
 validate.role.invalidModification=Cannot save with a role you do not have. You have: {0}
+validate.role.invalidRemoval=Cannot remove roles you do not have. You have: {0}
 validate.role.modifyOwnRoles=Cannot modify your own roles
 validate.role.noSpaceAllowed=Spaces are not allowed
 validate.role.cannotChangeXid=Cannot change role XID

--- a/Core/src/com/infiniteautomation/mango/spring/service/UsersService.java
+++ b/Core/src/com/infiniteautomation/mango/spring/service/UsersService.java
@@ -370,6 +370,7 @@ public class UsersService extends AbstractVOService<User, UserDao> implements Ca
 
         // validate roles
         permissionService.validatePermissionHolderRoles(result, "roles", holder,
+                existing.getRoles(),
                 vo.getRoles());
 
         // validate permissions


### PR DESCRIPTION
https://radixiot.atlassian.net/browse/RAD-4793

## Description

Fix editing user privilege escalation
Cherry picked from [RAD-4009](https://radixiot.atlassian.net/browse/RAD-4009)

Examples:

* https://radixiot.atlassian.net/browse/RAD-900
* "Adding pull request template since we don't have one"

## Current behavior

Currently, a non admin user can modify a role from a user when it's permissions should not allow it to do so.

## Expected behavior

a non admin user can not modify a role from a user when it's permissions should not allow it to do so.

## Tests



## Release Notes

Did you update the release notes?
(Yes / No and the reason it wasn't necessary)

[RAD-4009]: https://radixiot.atlassian.net/browse/RAD-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ