### PR TITLE
RAD-5064 [MANGO-332] - Upgrade Radix TSL dependency changes to 4.5.1

### DIFF
--- a/CoreBundle/pom.xml
+++ b/CoreBundle/pom.xml
@@ -444,7 +444,7 @@
         <dependency>
             <groupId>com.infiniteautomation.mango</groupId>
             <artifactId>radix-tsl</artifactId>
-            <version>4.5.0-SNAPSHOT</version>
+            <version>4.5.1-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Description
**BACKPORTING:**
* https://radixiot.atlassian.net/browse/MANGO-332

## Current behavior

* Currently when an exception is thrown on TSI insert, the PointValues are not reinserted and discarded and the BatchInserter queue size is not decreased

## Expected behavior

* Always decrease the BatchInserter queue size

## Changes
* Upgrade the radix-tsl dependency

## Resources

## Tests
* Current tests still working

## Release Notes

Did you update the release notes?
yes

* Upgrade Radix TSL dependency to  0.4.2-SNAPSHOT

