### PR TITLE
RAD-5526-Websocket-Bug

### DIFF
--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -1,3 +1,5 @@
+*Version 4.5.5*
+* Upgrade Jetty web server to version 9.4.53.v20231009
 
 *Version 4.5.4*
 * Enable use of OIDC/OAuth JWT bearer tokens.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>Mango Parent</name>
     <packaging>pom</packaging>
     <properties>
-        <jettyVersion>9.4.43.v20210629</jettyVersion>
+        <jettyVersion>9.4.53.v20231009</jettyVersion>
         <springVersion>5.3.18</springVersion>
         <springSecurityVersion>5.4.2</springSecurityVersion>
         <log4jVersion>2.17.1</log4jVersion>


### PR DESCRIPTION
Jetty 9.4.43 contains a bug that results in increased JVM usage. Upgrading to Jetty 9.4.53 will resolve this bug.

Major websocket memory change in 9.4.36
BUG
 

The commit in Mango 5 to cherry pick: [mango: //github Update Jetty to 9.4.53.v20231009](https://github.com/RadixIoT/mango/commit/43f5616bb962584fecd8641cafb7f51690b32e00) 

No other changes were made in that commit, so theoretically this version is compatible with your code.