### PR TITLE
[MANGO-1421] Authentication events are generated every time a request containing a bearer token is received

### DIFF
--- a/Core/RELEASE-NOTES
+++ b/Core/RELEASE-NOTES
@@ -1,8 +1,11 @@
+*Version 4.5.6*
+* Regression fix for OIDC/OAuth JWT bearer tokens that causing event for each request
+
 *Version 4.5.5*
 * Upgrade Jetty web server to version 9.4.53.v20231009
 
 *Version 4.5.4*
-* Enable use of OIDC/OAuth JWT bearer tokens.
+* Enable use of OIDC/OAuth JWT bearer tokens
 
 *Version 4.5.3*
 * Allowing grateful fallback when Ldap server is down.
@@ -13,7 +16,6 @@
 * Allow audit events when saving object without changes
 * Fix to allow users to remove roles from other users only when their permissions allows them to do so.
 * Fixes an infinite loop bug that creates megabytes of logs per second on a Modbus communication error
-
 
 *Version 4.5.1*
 * Improve performance for new points by setting the point value cache to an empty collection

--- a/Core/src/com/serotonin/m2m2/web/mvc/spring/security/MangoSecurityConfiguration.java
+++ b/Core/src/com/serotonin/m2m2/web/mvc/spring/security/MangoSecurityConfiguration.java
@@ -5,6 +5,7 @@ package com.serotonin.m2m2.web.mvc.spring.security;
 
 import static com.infiniteautomation.mango.spring.MangoRuntimeContextConfiguration.ANONYMOUS_PERMISSION_HOLDER;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +41,7 @@ import org.springframework.security.config.annotation.web.configurers.PortMapper
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.userdetails.UserDetailsChecker;
-import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
@@ -383,7 +384,13 @@ public class MangoSecurityConfiguration {
                     @Override
                     public <O extends BearerTokenAuthenticationFilter> O postProcess(O object) {
                         // ensure we use MangoAuthenticationDetailsSource with recordLogin = false
-                        object.setAuthenticationDetailsSource(authenticationDetailsSource);
+                        try {
+                            Field authenticationDetailsSourceField = BearerTokenAuthenticationFilter.class.getDeclaredField("authenticationDetailsSource");
+                            authenticationDetailsSourceField.setAccessible(true);
+                            authenticationDetailsSourceField.set(object, authenticationDetailsSource);
+                        } catch (NoSuchFieldException | IllegalAccessException e) {
+                            throw new IllegalStateException("Can't set authenticationDetailsSource field", e);
+                        }
                         return object;
                     }
                 }));


### PR DESCRIPTION
## Description

Backported changes from mango 5 https://github.com/RadixIoT/mango/pull/638

## Jira tickets
- https://radixiot.atlassian.net/browse/MANGO-1051
- https://radixiot.atlassian.net/browse/MANGO-1421

## Description

- Fix regression introduced by https://radixiot.atlassian.net/browse/MANGO-1051
- Configures the `BearerTokenAuthenticationFilter` to use the `MangoAuthenticationDetailsSource` so that login events are not generated by using a JWT token